### PR TITLE
Bootstrap sevrer

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -9,7 +9,7 @@ When used in a loadtest it will:
 
 It does all of this by exposing an RPC service which an agent uses to schedule a call.
 
-This library, then, is most useful when used with the rest of the go-lo suite but can realisitically be used by anything which works like a go-lo client.
+This library, then, is most useful when used with the rest of the go-lo suite but can realisitically be used by anything which works like a go-lo agent.
 
 A simple loadtest looks like:
 
@@ -19,50 +19,50 @@ A simple loadtest looks like:
      "log"
      "net/http"
 
-     "github.com/jspc/loadtest"
+     "github.com/go-lo/go-lo"
  )
 
- type MagnumAPI struct {
+ type API struct {
      URL string
  }
 
- func (m MagnumAPI) Run() {
+ func (a API) Run() {
      req, err := http.NewRequest("GET", m.URL, nil)
      if err != nil {
          panic(err)
      }
 
-     seq := loadtest.NewSequenceID()
+     seq := golo.NewSequenceID()
 
-     _ = loadtest.DoRequest(seq, req)
+     _ = golo.DoRequest(seq, req)
  }
 
  func main() {
-     m := MagnumAPI{
-         URL: "http://10.50.0.4:8765",
+     a := API{
+         URL: "http://localhost:8765",
      }
 
-     server := loadtest.NewServer(m)
+     server := golo.New(m)
 
-     panic(loadtest.StartListener(server))
+     panic(golo.Start(server))
  }
 
 The important steps are:
 
-     seq := loadtest.NewSequenceID()
+     seq := golo.NewSequenceID()
 
 A sequence ID is a string- using the same ID for all requests in a sequence of calls (completely analogous to a User Journey, say) allows us to identify slow routes better
 
 
-     _ = loadtest.DoRequest(seq, req)
+     _ = golo.DoRequest(seq, req)
 
 This executes *http.Request `req` with a sequence ID. This returns an *http.Response, and outputs pertinent json to STDOUT for the agent to pickup
 
 
-     server := loadtest.NewServer(m)
-     panic(loadtest.StartListener(server))
+     server := golo.New(m)
+     panic(golo.Start(server))
 
-This will take our implementation of the interface loadtest.Runner and start up the RPC listener
+This will take our implementation of the interface golo.Runner and start up the RPC listener
 
 */
 package golo

--- a/interface.go
+++ b/interface.go
@@ -3,6 +3,7 @@ package golo
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"net/rpc"
 )
 
@@ -29,9 +30,19 @@ type Server struct {
 	runner Runner
 }
 
-// NewServer takes scheduler code which implements the Runner
-// interface and returns a Server
-func NewServer(r Runner) Server {
+// New takes scheduler code which implements the Runner
+// interface and returns a Server. It also runs some bootstrap
+// tasks to ensure a server has various things set that it
+// ought to, like a clock and an HTTPClient
+func New(r Runner) Server {
+	if c == nil {
+		c = realClock{}
+	}
+
+	if Client == nil {
+		Client = &http.Client{}
+	}
+
 	return Server{r}
 }
 
@@ -42,9 +53,9 @@ func (s Server) Run(_ *NullArg, _ *NullArg) error {
 	return nil
 }
 
-// StartListener will start an RPC server on loadtest.RPCAddr
+// Start will start an RPC server on loadtest.RPCAddr
 // and register Server ahead of Agents scheduling jobs
-func StartListener(server Server) (err error) {
+func Start(server Server) (err error) {
 	s, l, err := setupListener(server)
 	if err != nil {
 		return

--- a/interface_test.go
+++ b/interface_test.go
@@ -16,11 +16,11 @@ func TestNewServer(t *testing.T) {
 		}
 	}()
 
-	NewServer(dummyRunner{})
+	New(dummyRunner{})
 }
 
 func TestServer_Run(t *testing.T) {
-	s := NewServer(dummyRunner{})
+	s := New(dummyRunner{})
 
 	err := s.Run(&NullArg{}, &NullArg{})
 	if err != nil {
@@ -29,7 +29,7 @@ func TestServer_Run(t *testing.T) {
 }
 
 func TestSetupListener(t *testing.T) {
-	s := NewServer(dummyRunner{})
+	s := New(dummyRunner{})
 
 	t.Run("clean configuration", func(t *testing.T) {
 		_, l, err := setupListener(s)

--- a/request.go
+++ b/request.go
@@ -48,10 +48,6 @@ const (
 // writer of a schedule, this function removes that boilerplate by
 // doing it it's self.
 func DoRequest(id string, req *http.Request) (response *http.Response) {
-	if Client == nil {
-		Client = &http.Client{}
-	}
-
 	if CloseRequests {
 		req.Close = true
 	}


### PR DESCRIPTION
Current jobs are failing because `c` isn't set. While fixing that it became obvious that:

 * We should be setting these things (like `golo.Client` also) at the earliest opportunity
 * We should be setting these things *once*

Moving these to `NewServer` changed, slightly, the point behind what `NewServer` does. It's less, now, a way of creating an rpc server, and more of an entrypoint into a `golo`.

Thus: `NewServer` becomes `New`, and `StartListener` becomes `Start`.

Bundled in are some docs changes