### PR TITLE
Recover any panics in runners

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -59,6 +59,13 @@ func New(r Runner) Server {
 
 // Run is the RPC interface into scheduler code
 func (s Server) Run(_ *NullArg, _ *NullArg) error {
+	defer func() {
+		err := recover()
+		if err != nil {
+			fmt.Errorf("%+v", err)
+		}
+	}()
+
 	s.runner.Run()
 
 	return nil


### PR DESCRIPTION
When schedulers panic (which happens, occasionally, during incredibly intensive loadtests) the whole test stops. But why?

We don't need these errors, we don't care if a loadtest panics, there's nothing to be gained- we're just running a function repeatedly. If one fails, the next one wont necessarily.

So sod it. `recover()` everything a schedule does.

Naturally we don't `recover()` 	_everything_ - just schedules