### PR TITLE
Extract errors when exist

### DIFF
--- a/output.go
+++ b/output.go
@@ -51,6 +51,11 @@ func Parse(id string, duration time.Duration, r *http.Request, resp *http.Respon
 // String outputs a marshal'd json string for the attached
 // Output. It swallows errors.
 func (o Output) String() string {
+	if o.Error != nil {
+		extractedError := o.Error
+		o.Error = extractedError.(error).Error()
+	}
+
 	output, _ := json.Marshal(o)
 
 	return string(output)

--- a/output.go
+++ b/output.go
@@ -52,8 +52,14 @@ func Parse(id string, duration time.Duration, r *http.Request, resp *http.Respon
 // Output. It swallows errors.
 func (o Output) String() string {
 	if o.Error != nil {
-		extractedError := o.Error
-		o.Error = extractedError.(error).Error()
+		switch o.Error.(type) {
+		case error:
+			extractedError := o.Error
+			o.Error = extractedError.(error).Error()
+
+		default:
+			// shrug
+		}
 	}
 
 	output, _ := json.Marshal(o)

--- a/output_test.go
+++ b/output_test.go
@@ -3,6 +3,7 @@
 package golo
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -35,6 +36,34 @@ func TestParse(t *testing.T) {
 			o := Parse(test.id, test.duration, test.request, test.response)
 			if test.expect != o.String() {
 				t.Errorf("expected `%s`, received `%s`", test.expect, o.String())
+			}
+		})
+	}
+}
+
+func TestOutput_String(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		output Output
+		expect string
+	}{
+		{"empty output",
+			Output{},
+			"{\"sequenceID\":\"\",\"url\":\"\",\"method\":\"\",\"status\":0,\"size\":0,\"timestamp\":\"0001-01-01T00:00:00Z\",\"duration\":0,\"error\":null}"},
+
+		{"succesful request",
+			Output{SequenceID: "", URL: "http://example.com", Method: "GET", Status: 200, Size: 13, Error: nil},
+			"{\"sequenceID\":\"\",\"url\":\"http://example.com\",\"method\":\"GET\",\"status\":200,\"size\":13,\"timestamp\":\"0001-01-01T00:00:00Z\",\"duration\":0,\"error\":null}"},
+
+		{"erroring request",
+			Output{SequenceID: "", URL: "http://example.com", Method: "GET", Status: 0, Size: 0, Error: fmt.Errorf("uh-oh")},
+			"{\"sequenceID\":\"\",\"url\":\"http://example.com\",\"method\":\"GET\",\"status\":0,\"size\":0,\"timestamp\":\"0001-01-01T00:00:00Z\",\"duration\":0,\"error\":\"uh-oh\"}"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := test.output.String()
+
+			if test.expect != s {
+				t.Errorf("expected:\n%q\nreceived:\n%q", test.expect, s)
 			}
 		})
 	}


### PR DESCRIPTION
In golang an error is an [interface](https://godoc.org/builtin#error) which can be, trivially, implemented like:

```golang
type MyError struct {
	message string
}

func (e MyError) Error() string {
	return e.message
}
```

Currently this library accepts an error as an empty interface. If this interface includes fields, as above, which are not exposed publicly then the error message contains no error details.

Setting the field `Output.Error` to be an `error` rather than `interface{}` also doesn't help, though, for reasons.

By calling the `Error()` field on valid errors, and having `Output.Error` as an `interface{}`, we can grab the error string and log it.